### PR TITLE
Development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Jekyll 3.x static blog (GitHub Pages site) for "Aaren Xia".
+
+### Key gotchas
+
+- **No Gemfile exists.** Gems are installed globally via `sudo gem install`. The required gems are: `jekyll` (~>3.9), `jekyll-sitemap`, `jekyll-gist`, `jekyll-paginate`, `redcarpet`, `pygments.rb`.
+- **`_config.yml` uses deprecated keys** (`gems:` instead of `plugins:`, `pygments: true` instead of `highlighter: pygments`). These produce deprecation warnings but still work in Jekyll 3.x. Do not "fix" these unless the project owner requests it.
+- **`jekyll-gist` is not listed in `_config.yml`** but is required by `pages/markdown.md`. On GitHub Pages it is auto-loaded; locally you must use the local config override: `jekyll serve --config _config.yml,_config_local.yml`.
+- **`_config_local.yml`** overrides `baseurl`/`url` for localhost and adds the missing `jekyll-gist` and `jekyll-paginate` plugins. Always pass both configs for local dev.
+
+### Running locally
+
+```bash
+jekyll serve --config _config.yml,_config_local.yml --host 0.0.0.0 --port 4000
+```
+
+Site available at `http://localhost:4000/`.
+
+### Build
+
+```bash
+jekyll build --config _config.yml,_config_local.yml
+```
+
+Output goes to `_site/`.
+
+### Lint / Tests
+
+There are no automated tests or linting configured in this repository. Travis CI (`.travis.yml`) only echoes commit info.

--- a/_config_local.yml
+++ b/_config_local.yml
@@ -1,0 +1,8 @@
+# Local development overrides
+# Merges with _config.yml when passed via: jekyll serve --config _config.yml,_config_local.yml
+baseurl: ""
+url: "http://localhost:4000"
+gems:
+  - jekyll-sitemap
+  - jekyll-gist
+  - jekyll-paginate


### PR DESCRIPTION
Add local Jekyll configuration to enable the development environment and `AGENTS.md` for setup documentation.

The `_config_local.yml` file addresses discrepancies between GitHub Pages' auto-loaded plugins (e.g., `jekyll-gist`) and local Jekyll's requirements, and overrides `baseurl`/`url` for local serving. This ensures the site builds and runs correctly in a local development setup without altering the original configuration.

---
<p><a href="https://cursor.com/agents/bc-dbfb85cb-81e0-4068-9447-a8c99c764b9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbfb85cb-81e0-4068-9447-a8c99c764b9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

